### PR TITLE
Don't use &String for arguments but rather &str

### DIFF
--- a/src/alias.rs
+++ b/src/alias.rs
@@ -86,10 +86,10 @@ impl AliasesList {
         self.aliases.sort_unstable();
     }
 
-    pub fn unalias_mime_type(&self, mime_type: &String) -> Option<String> {
+    pub fn unalias_mime_type(&self, mime_type: &str) -> Option<String> {
         for a in self.aliases.iter() {
             if a.alias == *mime_type {
-                return Some(a.mime_type.clone());
+                return Some(a.mime_type.to_string());
             }
         }
 

--- a/src/glob.rs
+++ b/src/glob.rs
@@ -205,7 +205,7 @@ impl Glob {
         })
     }
 
-    fn compare(&self, file_name: &String) -> bool {
+    fn compare(&self, file_name: &str) -> bool {
         match &self.glob {
             GlobType::Literal(s) => {
                 let a = UniCase::new(s);
@@ -299,7 +299,7 @@ impl GlobMap {
         self.globs.extend(globs);
     }
 
-    pub fn lookup_mime_type_for_file_name(&self, file_name: &String) -> Option<Vec<String>> {
+    pub fn lookup_mime_type_for_file_name(&self, file_name: &str) -> Option<Vec<String>> {
         let mut matching_globs = Vec::new();
 
         for glob in &self.globs {

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -43,7 +43,7 @@ impl Icon {
         }
     }
 
-    pub fn from_string(s: String) -> Option<Icon> {
+    pub fn from_string(s: &str) -> Option<Icon> {
         let mut chunks = s.split(':');
 
         let mime_type = match chunks.next() {
@@ -86,7 +86,7 @@ pub fn read_icons_from_file<P: AsRef<Path>>(file_name: P) -> Vec<Icon> {
             continue;
         }
 
-        match Icon::from_string(line) {
+        match Icon::from_string(&line) {
             Some(v) => res.push(v),
             None => continue,
         }
@@ -97,9 +97,9 @@ pub fn read_icons_from_file<P: AsRef<Path>>(file_name: P) -> Vec<Icon> {
     res
 }
 
-pub fn find_icon(icons: &Vec<Icon>, mime_type: &String) -> Option<String> {
+pub fn find_icon(icons: &Vec<Icon>, mime_type: &str) -> Option<String> {
     for icon in icons {
-        if &icon.mime_type == mime_type {
+        if icon.mime_type == mime_type {
             return Some(icon.icon_name.clone());
         }
     }
@@ -114,7 +114,7 @@ mod tests {
     #[test]
     fn from_str() {
         assert_eq!(
-            Icon::from_string("application/rss+xml:text-html".to_string()).unwrap(),
+            Icon::from_string("application/rss+xml:text-html").unwrap(),
             Icon::new("text-html", "application/rss+xml")
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,14 +184,14 @@ impl SharedMimeInfo {
     }
 
     /// Retrieves the MIME type aliased by @mime_type, if any.
-    pub fn unalias_mime_type(&self, mime_type: &String) -> Option<String> {
+    pub fn unalias_mime_type(&self, mime_type: &str) -> Option<String> {
         self.aliases.unalias_mime_type(mime_type)
     }
 
     /// Looks up the icons associated to a MIME type.
     ///
     /// The icons can be looked up within the current icon theme.
-    pub fn lookup_icon_names(&self, mime_type: &String) -> Vec<String> {
+    pub fn lookup_icon_names(&self, mime_type: &str) -> Vec<String> {
         let mut res = Vec::new();
 
         match icon::find_icon(&self.icons, &mime_type) {
@@ -199,7 +199,7 @@ impl SharedMimeInfo {
             None => {}
         };
 
-        res.push(mime_type.clone().replace("/", "-"));
+        res.push(mime_type.replace("/", "-"));
 
         match icon::find_icon(&self.generic_icons, mime_type) {
             Some(v) => res.push(v),
@@ -217,7 +217,7 @@ impl SharedMimeInfo {
     /// Looks up the generic icon associated to a MIME type.
     ///
     /// The icon can be looked up within the current icon theme.
-    pub fn lookup_generic_icon_name(&self, mime_type: &String) -> Option<String> {
+    pub fn lookup_generic_icon_name(&self, mime_type: &str) -> Option<String> {
         let res = match icon::find_icon(&self.generic_icons, mime_type) {
             Some(v) => v,
             None => {
@@ -231,7 +231,7 @@ impl SharedMimeInfo {
     }
 
     /// Looks up all the parent MIME types associated to @mime_type
-    pub fn get_parents(&self, mime_type: &String) -> Option<Vec<String>> {
+    pub fn get_parents(&self, mime_type: &str) -> Option<Vec<String>> {
         let unaliased = match self.aliases.unalias_mime_type(mime_type) {
             Some(v) => v,
             None => return None,
@@ -254,7 +254,7 @@ impl SharedMimeInfo {
 
     /// Retrieves the list of matching MIME types for the given file name,
     /// without looking at the data inside the file.
-    pub fn get_mime_types_from_file_name(&self, file_name: &String) -> Vec<String> {
+    pub fn get_mime_types_from_file_name(&self, file_name: &str) -> Vec<String> {
         let matching_types = match self.globs.lookup_mime_type_for_file_name(file_name) {
             Some(v) => v,
             None => {
@@ -306,11 +306,11 @@ mod tests {
         let mime_db = load_test_data();
 
         assert_eq!(
-            mime_db.lookup_generic_icon_name(&"application/json".to_string()),
+            mime_db.lookup_generic_icon_name("application/json"),
             Some("text-x-script".to_string())
         );
         assert_eq!(
-            mime_db.lookup_generic_icon_name(&"text/plain".to_string()),
+            mime_db.lookup_generic_icon_name("text/plain"),
             Some("text-x-generic".to_string())
         );
     }
@@ -320,10 +320,10 @@ mod tests {
         let mime_db = load_test_data();
 
         assert_eq!(
-            mime_db.unalias_mime_type(&"application/ics".to_string()),
+            mime_db.unalias_mime_type("application/ics"),
             Some("text/calendar".to_string())
         );
-        assert_eq!(mime_db.unalias_mime_type(&"text/plain".to_string()), None);
+        assert_eq!(mime_db.unalias_mime_type("text/plain"), None);
     }
 
     #[test]
@@ -331,12 +331,12 @@ mod tests {
         let mime_db = load_test_data();
 
         assert_eq!(
-            mime_db.get_mime_types_from_file_name(&"foo.txt".to_string()),
+            mime_db.get_mime_types_from_file_name("foo.txt"),
             vec!["text/plain".to_string()]
         );
 
         assert_eq!(
-            mime_db.get_mime_types_from_file_name(&"bar.gif".to_string()),
+            mime_db.get_mime_types_from_file_name("bar.gif"),
             vec!["image/gif".to_string()]
         );
     }


### PR DESCRIPTION
In general if you want to pass a string to a function, pass a `&str`.

- it automatically accept `&String`
- it allows string literal (In the tests you do `&"literal".to_string()`

So in general it is better.

So same can be for `&Vec<>` that can be replaced with `&[]`