### PR TITLE
Shorten parsers

### DIFF
--- a/src/alias.rs
+++ b/src/alias.rs
@@ -43,7 +43,7 @@ impl Alias {
         }
     }
 
-    pub fn from_string(s: String) -> Option<Alias> {
+    pub fn from_string(s: &str) -> Option<Alias> {
         let mut chunks = s.split_whitespace().fuse();
         let alias = chunks.next()?;
         let mime_type = chunks.next()?;
@@ -99,7 +99,7 @@ pub fn read_aliases_from_file<P: AsRef<Path>>(file_name: P) -> Vec<Alias> {
             continue;
         }
 
-        match Alias::from_string(line) {
+        match Alias::from_string(&line) {
             Some(v) => res.push(v),
             None => continue,
         }
@@ -131,7 +131,7 @@ mod tests {
     #[test]
     fn from_str() {
         assert_eq!(
-            Alias::from_string("application/x-foo application/foo".to_string()).unwrap(),
+            Alias::from_string("application/x-foo application/foo").unwrap(),
             Alias::new("application/x-foo", "application/foo")
         );
     }

--- a/src/alias.rs
+++ b/src/alias.rs
@@ -48,6 +48,11 @@ impl Alias {
         let alias = chunks.next()?;
         let mime_type = chunks.next()?;
 
+        // Consume the leftovers, if any
+        if chunks.next().is_some() {
+            return None;
+        }
+
         Some(Alias::new(alias, mime_type))
     }
 }
@@ -134,5 +139,10 @@ mod tests {
             Alias::from_string("application/x-foo application/foo").unwrap(),
             Alias::new("application/x-foo", "application/foo")
         );
+    }
+
+    #[test]
+    fn extra_tokens_yield_error() {
+        assert!(Alias::from_string("one/foo two/foo three/foo").is_none());
     }
 }

--- a/src/alias.rs
+++ b/src/alias.rs
@@ -44,22 +44,11 @@ impl Alias {
     }
 
     pub fn from_string(s: String) -> Option<Alias> {
-        let mut chunks = s.split_whitespace();
+        let mut chunks = s.split_whitespace().fuse();
+        let alias = chunks.next()?;
+        let mime_type = chunks.next()?;
 
-        let alias = match chunks.next() {
-            Some(v) => v.to_string(),
-            None => return None,
-        };
-
-        let mime_type = match chunks.next() {
-            Some(v) => v.to_string(),
-            None => return None,
-        };
-
-        Some(Alias {
-            alias,
-            mime_type,
-        })
+        Some(Alias::new(alias, mime_type))
     }
 }
 

--- a/src/glob.rs
+++ b/src/glob.rs
@@ -104,37 +104,16 @@ impl Glob {
     }
 
     pub fn from_v1_string(s: &str) -> Option<Glob> {
-        if s.is_empty() || !s.contains(':') {
-            return None;
-        }
-
-        let mut chunks = s.split(':');
-
-        let mime_type = match chunks.next() {
-            Some(v) => v.to_string(),
-            None => return None,
-        };
-
-        let glob = match chunks.next() {
-            Some(v) => v.to_string(),
-            None => return None,
-        };
-
-        if mime_type.is_empty() || glob.is_empty() {
-            return None;
-        }
+        let mut chunks = s.split(':').fuse();
+        let mime_type = chunks.next().filter(|s| !s.is_empty())?;
+        let glob = chunks.next().filter(|s| !s.is_empty())?;
 
         // Consume the leftovers, if any
-        if chunks.count() != 0 {
+        if chunks.next().is_some() {
             return None;
         }
 
-        Some(Glob {
-            glob: determine_type(&glob),
-            mime_type,
-            weight: 50,
-            case_sensitive: false,
-        })
+        Some(Glob::new(mime_type, glob, 50, false))
     }
 
     pub fn from_v2_string(s: &str) -> Option<Glob> {

--- a/src/parent.rs
+++ b/src/parent.rs
@@ -21,22 +21,11 @@ impl Subclass {
     }
 
     fn from_string(s: String) -> Option<Subclass> {
-        let mut chunks = s.split_whitespace();
+        let mut chunks = s.split_whitespace().fuse();
+        let mime_type = chunks.next()?;
+        let parent_type = chunks.next()?;
 
-        let mime_type = match chunks.next() {
-            Some(v) => v.to_string(),
-            None => return None,
-        };
-
-        let parent_type = match chunks.next() {
-            Some(v) => v.to_string(),
-            None => return None,
-        };
-
-        Some(Subclass {
-            mime_type,
-            parent_type,
-        })
+        Some(Subclass::new(mime_type, parent_type))
     }
 }
 

--- a/src/parent.rs
+++ b/src/parent.rs
@@ -20,7 +20,7 @@ impl Subclass {
         }
     }
 
-    fn from_string(s: String) -> Option<Subclass> {
+    fn from_string(s: &str) -> Option<Subclass> {
         let mut chunks = s.split_whitespace().fuse();
         let mime_type = chunks.next()?;
         let parent_type = chunks.next()?;
@@ -100,7 +100,7 @@ pub fn read_subclasses_from_file<P: AsRef<Path>>(file_name: P) -> Vec<Subclass> 
             continue;
         }
 
-        match Subclass::from_string(line) {
+        match Subclass::from_string(&line) {
             Some(v) => res.push(v),
             None => continue,
         }
@@ -124,7 +124,7 @@ mod tests {
     #[test]
     fn from_str() {
         assert_eq!(
-            Subclass::from_string("message/partial text/plain".to_string()).unwrap(),
+            Subclass::from_string("message/partial text/plain").unwrap(),
             Subclass::new("message/partial", "text/plain")
         );
     }

--- a/src/parent.rs
+++ b/src/parent.rs
@@ -25,6 +25,11 @@ impl Subclass {
         let mime_type = chunks.next()?;
         let parent_type = chunks.next()?;
 
+        // Consume the leftovers, if any
+        if chunks.next().is_some() {
+            return None;
+        }
+
         Some(Subclass::new(mime_type, parent_type))
     }
 }
@@ -140,5 +145,10 @@ mod tests {
             pm.lookup(&"message/partial".to_string()),
             Some(&vec!["text/plain".to_string(),])
         );
+    }
+
+    #[test]
+    fn extra_tokens_yield_error() {
+        assert!(Subclass::from_string("one/foo two/foo three/foo").is_none());
     }
 }


### PR DESCRIPTION
Shorten the Subclass/Icon/Alias/Glob parsers with More Idiomaticity(tm).

Two similar changes I'm not sure about, but at least it looks like they are from making them consistent with the others:  Subclass and Alias now make it an error if there are extra tokens after the two consumed ones.