### PR TITLE
Use the mime crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ doctest = false
 [dependencies]
 dirs = "2.0"
 glob = "0.3.0"
+mime = "0.3"
 nom = "^5"
 unicase = "2.3.0"
 

--- a/src/alias.rs
+++ b/src/alias.rs
@@ -98,6 +98,10 @@ pub fn read_aliases_from_file<P: AsRef<Path>>(file_name: P) -> Vec<Alias> {
 
     let file = BufReader::new(&f);
     for line in file.lines() {
+        if line.is_err() {
+            return res; // FIXME: return error instead
+        }
+
         let line = line.unwrap();
 
         if line.is_empty() || line.starts_with('#') {

--- a/src/alias.rs
+++ b/src/alias.rs
@@ -4,11 +4,14 @@ use std::fs::File;
 use std::io::BufRead;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use mime::Mime;
 
 #[derive(Clone, Eq)]
 pub struct Alias {
-    pub alias: String,
-    pub mime_type: String,
+    pub alias: Mime,
+    pub mime_type: Mime,
 }
 
 impl fmt::Debug for Alias {
@@ -36,24 +39,24 @@ impl PartialOrd for Alias {
 }
 
 impl Alias {
-    pub fn new(alias: &str, mime_type: &str) -> Alias {
+    pub fn new(alias: &Mime, mime_type: &Mime) -> Alias {
         Alias {
-            alias: alias.to_string(),
-            mime_type: mime_type.to_string(),
+            alias: alias.clone(),
+            mime_type: mime_type.clone(),
         }
     }
 
     pub fn from_string(s: &str) -> Option<Alias> {
         let mut chunks = s.split_whitespace().fuse();
-        let alias = chunks.next()?;
-        let mime_type = chunks.next()?;
+        let alias = chunks.next().and_then(|s| Mime::from_str(s).ok())?;
+        let mime_type = chunks.next().and_then(|s| Mime::from_str(s).ok())?;
 
         // Consume the leftovers, if any
         if chunks.next().is_some() {
             return None;
         }
 
-        Some(Alias::new(alias, mime_type))
+        Some(Alias { alias, mime_type })
     }
 }
 
@@ -80,11 +83,11 @@ impl AliasesList {
         self.aliases.sort_unstable();
     }
 
-    pub fn unalias_mime_type(&self, mime_type: &str) -> Option<String> {
+    pub fn unalias_mime_type(&self, mime_type: &Mime) -> Option<Mime> {
         self.aliases
             .iter()
-            .find(|a| a.alias == mime_type)
-            .map(|a| a.mime_type.to_string())
+            .find(|a| a.alias == *mime_type)
+            .map(|a| a.mime_type.clone())
     }
 }
 
@@ -132,8 +135,14 @@ mod tests {
     #[test]
     fn new_alias() {
         assert_eq!(
-            Alias::new("application/foo", "application/foo"),
-            Alias::new("application/foo", "application/x-foo")
+            Alias::new(
+                &Mime::from_str("application/foo").unwrap(),
+                &Mime::from_str("application/foo").unwrap()
+            ),
+            Alias::new(
+                &Mime::from_str("application/foo").unwrap(),
+                &Mime::from_str("application/x-foo").unwrap()
+            ),
         );
     }
 
@@ -141,7 +150,10 @@ mod tests {
     fn from_str() {
         assert_eq!(
             Alias::from_string("application/x-foo application/foo").unwrap(),
-            Alias::new("application/x-foo", "application/foo")
+            Alias::new(
+                &Mime::from_str("application/x-foo").unwrap(),
+                &Mime::from_str("application/foo").unwrap(),
+            )
         );
     }
 

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -66,6 +66,10 @@ pub fn read_icons_from_file<P: AsRef<Path>>(file_name: P) -> Vec<Icon> {
     let mut res = Vec::new();
     let file = BufReader::new(&f);
     for line in file.lines() {
+        if line.is_err() {
+            return res; // FIXME: return error instead
+        }
+
         let line = line.unwrap();
 
         if line.is_empty() || line.starts_with('#') {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,12 +27,6 @@ mod icon;
 mod magic;
 mod parent;
 
-/// Convenience identifier for an unknown MIME type.
-pub const UNKNOWN_TYPE: Mime = mime::APPLICATION_OCTET_STREAM;
-
-/// Convenience identifier for the MIME type for an empty file.
-pub static EMPTY_TYPE: &str = "application/x-zerosize";
-
 pub struct SharedMimeInfo {
     aliases: alias::AliasesList,
     parents: parent::ParentsMap,
@@ -183,12 +177,15 @@ impl SharedMimeInfo {
 
     /// Retrieves the list of matching MIME types for the given file name,
     /// without looking at the data inside the file.
+    ///
+    /// If no specific MIME-type can be determined, returns a single
+    /// element vector with `application/octet-stream`.
     pub fn get_mime_types_from_file_name(&self, file_name: &str) -> Vec<Mime> {
         match self.globs.lookup_mime_type_for_file_name(file_name) {
             Some(v) => v,
             None => {
                 let mut res = Vec::new();
-                res.push(UNKNOWN_TYPE.clone());
+                res.push(mime::APPLICATION_OCTET_STREAM.clone());
                 res
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,6 @@
 /// [xdg-mime]: https://specifications.freedesktop.org/shared-mime-info-spec/shared-mime-info-spec-latest.html
 use std::env;
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 
 use mime::Mime;
 
@@ -29,13 +28,10 @@ mod magic;
 mod parent;
 
 /// Convenience identifier for an unknown MIME type.
-pub static UNKNOWN_TYPE: &str = "application/octet-stream";
+pub const UNKNOWN_TYPE: Mime = mime::APPLICATION_OCTET_STREAM;
 
 /// Convenience identifier for the MIME type for an empty file.
 pub static EMPTY_TYPE: &str = "application/x-zerosize";
-
-/// Convenience identifier for the MIME type for a plain text file.
-pub static TEXT_PLAIN_TYPE: &str = "text/plain";
 
 pub struct SharedMimeInfo {
     aliases: alias::AliasesList,
@@ -125,28 +121,26 @@ impl SharedMimeInfo {
     }
 
     /// Retrieves the MIME type aliased by a MIME type, if any.
-    pub fn unalias_mime_type(&self, mime_type: &str) -> Option<String> {
+    pub fn unalias_mime_type(&self, mime_type: &Mime) -> Option<Mime> {
         self.aliases.unalias_mime_type(mime_type)
     }
 
     /// Looks up the icons associated to a MIME type.
     ///
     /// The icons can be looked up within the current icon theme.
-    pub fn lookup_icon_names(&self, mime_type: &str) -> Vec<String> {
+    pub fn lookup_icon_names(&self, mime_type: &Mime) -> Vec<String> {
         let mut res = Vec::new();
 
-        if let Some(v) = icon::find_icon(&self.icons, &mime_type) {
+        if let Some(v) = icon::find_icon(&self.icons, mime_type) {
             res.push(v);
         };
 
-        res.push(mime_type.replace("/", "-"));
+        res.push(mime_type.essence_str().replace("/", "-"));
 
         match icon::find_icon(&self.generic_icons, mime_type) {
             Some(v) => res.push(v),
             None => {
-                let split_type = mime_type.split('/').collect::<Vec<&str>>();
-
-                let generic = format!("{}-x-generic", split_type.get(0).unwrap());
+                let generic = format!("{}-x-generic", mime_type.type_());
                 res.push(generic);
             }
         };
@@ -157,13 +151,11 @@ impl SharedMimeInfo {
     /// Looks up the generic icon associated to a MIME type.
     ///
     /// The icon can be looked up within the current icon theme.
-    pub fn lookup_generic_icon_name(&self, mime_type: &str) -> Option<String> {
+    pub fn lookup_generic_icon_name(&self, mime_type: &Mime) -> Option<String> {
         let res = match icon::find_icon(&self.generic_icons, mime_type) {
             Some(v) => v,
             None => {
-                let split_type = mime_type.split('/').collect::<Vec<&str>>();
-
-                format!("{}-x-generic", split_type.get(0).unwrap())
+                format!("{}-x-generic", mime_type.type_())
             }
         };
 
@@ -171,7 +163,7 @@ impl SharedMimeInfo {
     }
 
     /// Looks up all the parent MIME types associated to @mime_type
-    pub fn get_parents(&self, mime_type: &str) -> Option<Vec<String>> {
+    pub fn get_parents(&self, mime_type: &Mime) -> Option<Vec<Mime>> {
         let unaliased = match self.aliases.unalias_mime_type(mime_type) {
             Some(v) => v,
             None => return None,
@@ -180,12 +172,9 @@ impl SharedMimeInfo {
         let mut res = Vec::new();
         res.push(unaliased.clone());
 
-        // FIXME: convert aliases module to Mime
-        let unaliased = Mime::from_str(&unaliased).ok()?;
-
         if let Some(parents) = self.parents.lookup(&unaliased) {
             for parent in parents {
-                res.push(parent.essence_str().to_string());
+                res.push(parent.clone());
             }
         };
 
@@ -194,12 +183,12 @@ impl SharedMimeInfo {
 
     /// Retrieves the list of matching MIME types for the given file name,
     /// without looking at the data inside the file.
-    pub fn get_mime_types_from_file_name(&self, file_name: &str) -> Vec<String> {
+    pub fn get_mime_types_from_file_name(&self, file_name: &str) -> Vec<Mime> {
         match self.globs.lookup_mime_type_for_file_name(file_name) {
             Some(v) => v,
             None => {
                 let mut res = Vec::new();
-                res.push(UNKNOWN_TYPE.to_string());
+                res.push(UNKNOWN_TYPE.clone());
                 res
             }
         }
@@ -207,41 +196,42 @@ impl SharedMimeInfo {
 
     /// Retrieves the MIME type for the given data, and the priority of the
     /// match. A priority above 80 means a certain match.
-    pub fn get_mime_type_for_data(&self, data: &[u8]) -> Option<(String, u32)> {
+    pub fn get_mime_type_for_data(&self, data: &[u8]) -> Option<(Mime, u32)> {
         magic::lookup_data(&self.magic, data)
     }
 
     /// Checks whether two MIME types are equal, taking into account
     /// eventual aliases.
-    pub fn mime_type_equal(&self, mime_a: &str, mime_b: &str) -> bool {
+    pub fn mime_type_equal(&self, mime_a: &Mime, mime_b: &Mime) -> bool {
         let unaliased_a = self
             .unalias_mime_type(mime_a)
-            .unwrap_or_else(|| mime_a.to_string());
+            .unwrap_or_else(|| mime_a.clone());
         let unaliased_b = self
             .unalias_mime_type(mime_b)
-            .unwrap_or_else(|| mime_b.to_string());
+            .unwrap_or_else(|| mime_b.clone());
 
         unaliased_a == unaliased_b
     }
 
     /// Checks whether a MIME type is a subclass of another MIME type
-    pub fn mime_type_subclass(&self, mime_type: &str, base: &str) -> bool {
+    pub fn mime_type_subclass(&self, mime_type: &Mime, base: &Mime) -> bool {
         let unaliased_mime = self
             .unalias_mime_type(mime_type)
-            .unwrap_or_else(|| mime_type.to_string());
+            .unwrap_or_else(|| mime_type.clone());
         let unaliased_base = self
             .unalias_mime_type(base)
-            .unwrap_or_else(|| base.to_string());
+            .unwrap_or_else(|| base.clone());
 
         if unaliased_mime == unaliased_base {
             return true;
         }
 
         // Handle super-types
-        if unaliased_base.ends_with("/*") {
-            let chunks = unaliased_base.split('/').collect::<Vec<&str>>();
+        if unaliased_base.subtype() == mime::STAR {
+            let base_type = unaliased_base.type_();
+            let unaliased_type = unaliased_mime.type_();
 
-            if unaliased_mime.starts_with(chunks.get(0).unwrap()) {
+            if base_type == unaliased_type {
                 return true;
             }
         }
@@ -254,20 +244,17 @@ impl SharedMimeInfo {
         //    inode/* types) are subclasses of application/octet-stream
         //
         // https://specifications.freedesktop.org/shared-mime-info-spec/shared-mime-info-spec-latest.html#subclassing
-        if unaliased_base == "text/plain" && unaliased_mime.starts_with("text/") {
+        if unaliased_base == mime::TEXT_PLAIN && unaliased_mime.type_() == mime::TEXT {
             return true;
         }
 
-        if unaliased_base == "application/octet-stream" && !unaliased_mime.starts_with("inode/") {
+        if unaliased_base == mime::APPLICATION_OCTET_STREAM && unaliased_mime.type_() != "inode" {
             return true;
         }
-
-        // FIXME: convert to Mime
-        let unaliased_mime = Mime::from_str(&unaliased_mime).unwrap();
 
         if let Some(parents) = self.parents.lookup(&unaliased_mime) {
             for parent in parents {
-                if self.mime_type_subclass(parent.essence_str(), &unaliased_base) {
+                if self.mime_type_subclass(parent, &unaliased_base) {
                     return true;
                 }
             }
@@ -281,6 +268,7 @@ impl SharedMimeInfo {
 mod tests {
     use super::*;
     use std::env;
+    use std::str::FromStr;
 
     fn load_test_data() -> SharedMimeInfo {
         let cwd = env::current_dir().unwrap().to_string_lossy().into_owned();
@@ -310,11 +298,11 @@ mod tests {
         let mime_db = load_test_data();
 
         assert_eq!(
-            mime_db.lookup_generic_icon_name("application/json"),
+            mime_db.lookup_generic_icon_name(&mime::APPLICATION_JSON),
             Some("text-x-script".to_string())
         );
         assert_eq!(
-            mime_db.lookup_generic_icon_name("text/plain"),
+            mime_db.lookup_generic_icon_name(&mime::TEXT_PLAIN),
             Some("text-x-generic".to_string())
         );
     }
@@ -324,10 +312,10 @@ mod tests {
         let mime_db = load_test_data();
 
         assert_eq!(
-            mime_db.unalias_mime_type("application/ics"),
-            Some("text/calendar".to_string())
+            mime_db.unalias_mime_type(&Mime::from_str("application/ics").unwrap()),
+            Some(Mime::from_str("text/calendar").unwrap())
         );
-        assert_eq!(mime_db.unalias_mime_type("text/plain"), None);
+        assert_eq!(mime_db.unalias_mime_type(&Mime::from_str("text/plain").unwrap()), None);
     }
 
     #[test]
@@ -335,27 +323,47 @@ mod tests {
         let mime_db = load_test_data();
 
         assert_eq!(
-            mime_db.mime_type_equal("application/wordperfect", "application/vnd.wordperfect"),
+            mime_db.mime_type_equal(
+                &Mime::from_str("application/wordperfect").unwrap(),
+                &Mime::from_str("application/vnd.wordperfect").unwrap(),
+            ),
             true
         );
         assert_eq!(
-            mime_db.mime_type_equal("application/x-gnome-app-info", "application/x-desktop"),
+            mime_db.mime_type_equal(
+                &Mime::from_str("application/x-gnome-app-info").unwrap(),
+                &Mime::from_str("application/x-desktop").unwrap(),
+            ),
             true
         );
         assert_eq!(
-            mime_db.mime_type_equal("application/x-wordperfect", "application/vnd.wordperfect"),
+            mime_db.mime_type_equal(
+                &Mime::from_str("application/x-wordperfect").unwrap(),
+                &Mime::from_str("application/vnd.wordperfect").unwrap(),
+            ),
             true
         );
         assert_eq!(
-            mime_db.mime_type_equal("application/x-wordperfect", "audio/x-midi"),
+            mime_db.mime_type_equal(
+                &Mime::from_str("application/x-wordperfect").unwrap(),
+                &Mime::from_str("audio/x-midi").unwrap(),
+            ),
             false
         );
-        assert_eq!(mime_db.mime_type_equal("/", "vnd/vnd"), false);
         assert_eq!(
-            mime_db.mime_type_equal("application/octet-stream", "text/plain"),
+            mime_db.mime_type_equal(
+                &Mime::from_str("application/octet-stream").unwrap(),
+                &Mime::from_str("text/plain").unwrap(),
+            ),
             false
         );
-        assert_eq!(mime_db.mime_type_equal("text/plain", "text/*"), false);
+        assert_eq!(
+            mime_db.mime_type_equal(
+                &Mime::from_str("text/plain").unwrap(),
+                &Mime::from_str("text/*").unwrap(),
+            ),
+            false
+        );
     }
 
     #[test]
@@ -364,12 +372,12 @@ mod tests {
 
         assert_eq!(
             mime_db.get_mime_types_from_file_name("foo.txt"),
-            vec!["text/plain".to_string()]
+            vec![Mime::from_str("text/plain").unwrap()]
         );
 
         assert_eq!(
             mime_db.get_mime_types_from_file_name("bar.gif"),
-            vec!["image/gif".to_string()]
+            vec![Mime::from_str("image/gif").unwrap()]
         );
     }
 
@@ -380,13 +388,13 @@ mod tests {
         let svg_data = include_bytes!("../test_files/files/rust-logo.svg");
         assert_eq!(
             mime_db.get_mime_type_for_data(svg_data),
-            Some(("image/svg+xml".to_string(), 80))
+            Some((Mime::from_str("image/svg+xml").unwrap(), 80))
         );
 
         let png_data = include_bytes!("../test_files/files/rust-logo.png");
         assert_eq!(
             mime_db.get_mime_type_for_data(png_data),
-            Some(("image/png".to_string(), 50))
+            Some((Mime::from_str("image/png").unwrap(), 50))
         );
     }
 
@@ -395,46 +403,88 @@ mod tests {
         let mime_db = load_test_data();
 
         assert_eq!(
-            mime_db.mime_type_subclass("application/rtf", "text/plain"),
+            mime_db.mime_type_subclass(
+                &Mime::from_str("application/rtf").unwrap(),
+                &Mime::from_str("text/plain").unwrap(),
+            ),
             true
         );
         assert_eq!(
-            mime_db.mime_type_subclass("message/news", "text/plain"),
+            mime_db.mime_type_subclass(
+                &Mime::from_str("message/news").unwrap(),
+                &Mime::from_str("text/plain").unwrap(),
+            ),
             true
         );
         assert_eq!(
-            mime_db.mime_type_subclass("message/news", "message/*"),
-            true
-        );
-        assert_eq!(mime_db.mime_type_subclass("message/news", "text/*"), true);
-        assert_eq!(
-            mime_db.mime_type_subclass("message/news", "application/octet-stream"),
-            true
-        );
-        assert_eq!(
-            mime_db.mime_type_subclass("application/rtf", "application/octet-stream"),
+            mime_db.mime_type_subclass(
+                &Mime::from_str("message/news").unwrap(),
+                &Mime::from_str("message/*").unwrap(),
+            ),
             true
         );
         assert_eq!(
-            mime_db.mime_type_subclass("application/x-gnome-app-info", "text/plain"),
+            mime_db.mime_type_subclass(
+                &Mime::from_str("message/news").unwrap(),
+                &Mime::from_str("text/*").unwrap(),
+            ),
             true
         );
         assert_eq!(
-            mime_db.mime_type_subclass("image/x-djvu", "image/vnd.djvu"),
+            mime_db.mime_type_subclass(
+                &Mime::from_str("message/news").unwrap(),
+                &Mime::from_str("application/octet-stream").unwrap(),
+            ),
             true
         );
         assert_eq!(
-            mime_db.mime_type_subclass("image/vnd.djvu", "image/x-djvu"),
+            mime_db.mime_type_subclass(
+                &Mime::from_str("application/rtf").unwrap(),
+                &Mime::from_str("application/octet-stream").unwrap(),
+            ),
             true
         );
         assert_eq!(
-            mime_db.mime_type_subclass("image/vnd.djvu", "text/plain"),
+            mime_db.mime_type_subclass(
+                &Mime::from_str("application/x-gnome-app-info").unwrap(),
+                &Mime::from_str("text/plain").unwrap(),
+            ),
+            true
+        );
+        assert_eq!(
+            mime_db.mime_type_subclass(
+                &Mime::from_str("image/x-djvu").unwrap(),
+                &Mime::from_str("image/vnd.djvu").unwrap(),
+            ),
+            true
+        );
+        assert_eq!(
+            mime_db.mime_type_subclass(
+                &Mime::from_str("image/vnd.djvu").unwrap(),
+                &Mime::from_str("image/x-djvu").unwrap(),
+            ),
+            true
+        );
+        assert_eq!(
+            mime_db.mime_type_subclass(
+                &Mime::from_str("image/vnd.djvu").unwrap(),
+                &Mime::from_str("text/plain").unwrap(),
+            ),
             false
         );
         assert_eq!(
-            mime_db.mime_type_subclass("image/vnd.djvu", "text/*"),
+            mime_db.mime_type_subclass(
+                &Mime::from_str("image/vnd.djvu").unwrap(),
+                &Mime::from_str("text/*").unwrap(),
+            ),
             false
         );
-        assert_eq!(mime_db.mime_type_subclass("text/*", "text/plain"), true);
+        assert_eq!(
+            mime_db.mime_type_subclass(
+                &Mime::from_str("text/*").unwrap(),
+                &Mime::from_str("text/plain").unwrap(),
+            ),
+            true
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,9 @@
 /// [xdg-mime]: https://specifications.freedesktop.org/shared-mime-info-spec/shared-mime-info-spec-latest.html
 use std::env;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use mime::Mime;
 
 extern crate dirs;
 #[macro_use]
@@ -177,9 +180,12 @@ impl SharedMimeInfo {
         let mut res = Vec::new();
         res.push(unaliased.clone());
 
+        // FIXME: convert aliases module to Mime
+        let unaliased = Mime::from_str(&unaliased).ok()?;
+
         if let Some(parents) = self.parents.lookup(&unaliased) {
             for parent in parents {
-                res.push(parent.clone());
+                res.push(parent.essence_str().to_string());
             }
         };
 
@@ -256,9 +262,12 @@ impl SharedMimeInfo {
             return true;
         }
 
+        // FIXME: convert to Mime
+        let unaliased_mime = Mime::from_str(&unaliased_mime).unwrap();
+
         if let Some(parents) = self.parents.lookup(&unaliased_mime) {
             for parent in parents {
-                if self.mime_type_subclass(parent, &unaliased_base) {
+                if self.mime_type_subclass(parent.essence_str(), &unaliased_base) {
                     return true;
                 }
             }

--- a/src/parent.rs
+++ b/src/parent.rs
@@ -33,7 +33,7 @@ impl Subclass {
             return None;
         }
 
-        Some(Subclass::new(&mime_type, &parent_type))
+        Some(Subclass { mime_type, parent_type })
     }
 }
 

--- a/src/parent.rs
+++ b/src/parent.rs
@@ -102,6 +102,10 @@ pub fn read_subclasses_from_file<P: AsRef<Path>>(file_name: P) -> Vec<Subclass> 
     let mut res = Vec::new();
     let file = BufReader::new(&f);
     for line in file.lines() {
+        if line.is_err() {
+            return res; // FIXME: return error instead
+        }
+
         let line = line.unwrap();
 
         if line.is_empty() || line.starts_with('#') {

--- a/src/parent.rs
+++ b/src/parent.rs
@@ -5,32 +5,35 @@ use std::fs::File;
 use std::io::BufRead;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use mime::Mime;
 
 #[derive(Clone, Eq)]
 pub struct Subclass {
-    mime_type: String,
-    parent_type: String,
+    mime_type: Mime,
+    parent_type: Mime,
 }
 
 impl Subclass {
-    pub fn new(mime_type: &str, parent_type: &str) -> Subclass {
+    pub fn new(mime_type: &Mime, parent_type: &Mime) -> Subclass {
         Subclass {
-            mime_type: mime_type.to_string(),
-            parent_type: parent_type.to_string(),
+            mime_type: mime_type.clone(),
+            parent_type: parent_type.clone(),
         }
     }
 
     fn from_string(s: &str) -> Option<Subclass> {
         let mut chunks = s.split_whitespace().fuse();
-        let mime_type = chunks.next()?;
-        let parent_type = chunks.next()?;
+        let mime_type = chunks.next().and_then(|s| Mime::from_str(s).ok())?;
+        let parent_type = chunks.next().and_then(|s| Mime::from_str(s).ok())?;
 
         // Consume the leftovers, if any
         if chunks.next().is_some() {
             return None;
         }
 
-        Some(Subclass::new(mime_type, parent_type))
+        Some(Subclass::new(&mime_type, &parent_type))
     }
 }
 
@@ -59,7 +62,7 @@ impl PartialOrd for Subclass {
 }
 
 pub struct ParentsMap {
-    parents: HashMap<String, Vec<String>>,
+    parents: HashMap<Mime, Vec<Mime>>,
 }
 
 impl ParentsMap {
@@ -85,7 +88,7 @@ impl ParentsMap {
         }
     }
 
-    pub fn lookup(&self, mime_type: &str) -> Option<&Vec<String>> {
+    pub fn lookup(&self, mime_type: &Mime) -> Option<&Vec<Mime>> {
         self.parents.get(mime_type)
     }
 }
@@ -130,7 +133,10 @@ mod tests {
     fn from_str() {
         assert_eq!(
             Subclass::from_string("message/partial text/plain").unwrap(),
-            Subclass::new("message/partial", "text/plain")
+            Subclass::new(
+                &Mime::from_str("message/partial").unwrap(),
+                &Mime::from_str("text/plain").unwrap()
+            )
         );
     }
 
@@ -138,12 +144,18 @@ mod tests {
     fn parent_map() {
         let mut pm = ParentsMap::new();
 
-        pm.add_subclass(Subclass::new("message/partial", "text/plain"));
-        pm.add_subclass(Subclass::new("text/rfc822-headers", "text/plain"));
+        pm.add_subclass(Subclass::new(
+            &Mime::from_str("message/partial").unwrap(),
+            &Mime::from_str("text/plain").unwrap(),
+        ));
+        pm.add_subclass(Subclass::new(
+            &Mime::from_str("text/rfc822-headers").unwrap(),
+            &Mime::from_str("text/plain").unwrap(),
+        ));
 
         assert_eq!(
-            pm.lookup(&"message/partial".to_string()),
-            Some(&vec!["text/plain".to_string(),])
+            pm.lookup(&Mime::from_str("message/partial").unwrap()),
+            Some(&vec![Mime::from_str("text/plain").unwrap()]),
         );
     }
 


### PR DESCRIPTION
I don't know if you want to go this route, hence the WIP / partial PR:

This converts the `parent` module to use the `mime` crate.  It exports a `Mime` type for, well, a MIME type and its parameters.  Of interest here, I think, is that it actually validates MIME type names in its parser.

(Also I think it's good to use strongly-typed concepts instead of String.)

I can convert the rest of the code to Mime if you'd like it.