### PR TITLE
Replace for loops with iterators

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,13 +403,14 @@ impl<'a> GuessBuilder<'a> {
                 // file name, so let's see if the sniffed MIME type is
                 // a subclass of the MIME type associated to the file name,
                 // and use that as a tie breaker
-                for mime_type in &name_mime_types {
-                    if self.db.mime_type_subclass(&mime_type, &mime) {
-                        return Guess {
-                            mime: mime_type.clone(),
-                            uncertain: false,
-                        };
-                    }
+                if let Some(mime_type) = name_mime_types
+                    .iter()
+                    .find(|m| self.db.mime_type_subclass(m, &mime))
+                {
+                    return Guess {
+                        mime: mime_type.clone(),
+                        uncertain: false,
+                    };
                 }
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -431,21 +431,14 @@ impl<'a> GuessBuilder<'a> {
 }
 
 fn looks_like_text(data: &[u8]) -> bool {
-    for (i, ch) in data.iter().enumerate() {
-        // "Checking the first 128 bytes of the file for ASCII
-        // control characters is a good way to guess whether a
-        // file is binary or text."
-        // -- shared-mime-info, "Recommended checking order"
-        if i > 128 {
-            break;
-        }
-
-        if ch.is_ascii_control() && !ch.is_ascii_whitespace() {
-            return false;
-        }
-    }
-
-    true
+    // "Checking the first 128 bytes of the file for ASCII
+    // control characters is a good way to guess whether a
+    // file is binary or text."
+    // -- shared-mime-info, "Recommended checking order"
+    !data
+        .iter()
+        .take(128)
+        .any(|ch| ch.is_ascii_control() && !ch.is_ascii_whitespace())
 }
 
 impl Guess {

--- a/src/magic.rs
+++ b/src/magic.rs
@@ -32,7 +32,6 @@ pub fn buf_to_u32(s: &[u8], or_default: u32) -> u32 {
 struct MagicRule {
     indent: u32,
     start_offset: u32,
-    value_length: u16,
     value: Vec<u8>,
     mask: Option<Vec<u8>>,
     word_size: u32,
@@ -57,7 +56,6 @@ fn masked_slices_are_equal(a: &[u8], b: &[u8], mask: &[u8]) -> bool {
 
 impl MagicRule {
     fn matches_data(&self, data: &[u8]) -> bool {
-        assert!(self.value_length as usize == self.value.len());
         assert!(self.mask.is_none() || self.mask.as_ref().unwrap().len() == self.value.len());
 
         let start = self.start_offset as usize;
@@ -78,7 +76,7 @@ impl MagicRule {
     }
 
     fn extent(&self) -> usize {
-        let value_len = self.value_length as usize;
+        let value_len = self.value.len();
         let offset = self.start_offset as usize;
         let range_len = self.range_length as usize;
 
@@ -161,7 +159,6 @@ named!(
     >>  (MagicRule {
             indent: _indent,
             start_offset: _start_offset,
-            value_length: _value_length,
             value: _value,
             mask: _mask,
             word_size: _word_size.unwrap_or(1),
@@ -449,7 +446,6 @@ mod tests {
         let rule = MagicRule {
             indent: 0,
             start_offset: 0,
-            value_length: 5,
             value: vec!['h' as u8, 'e' as u8, 'l' as u8, 'l' as u8, 'o' as u8],
             mask: None,
             word_size: 1,
@@ -465,7 +461,6 @@ mod tests {
         let rule = MagicRule {
             indent: 0,
             start_offset: 1,
-            value_length: 5,
             value: vec!['h' as u8, 'e' as u8, 'l' as u8, 'l' as u8, 'o' as u8],
             mask: None,
             word_size: 1,
@@ -482,7 +477,6 @@ mod tests {
         let rule = MagicRule {
             indent: 0,
             start_offset: 0,
-            value_length: 5,
             value: vec!['h' as u8, 'e' as u8, 'l' as u8, 'l' as u8, 'o' as u8],
             mask: None,
             word_size: 1,
@@ -501,7 +495,6 @@ mod tests {
         let rule = MagicRule {
             indent: 0,
             start_offset: 1,
-            value_length: 5,
             value: vec!['h' as u8, 'e' as u8, 'l' as u8, 'l' as u8, 'o' as u8],
             mask: None,
             word_size: 1,
@@ -520,7 +513,6 @@ mod tests {
         let rule = MagicRule {
             indent: 0,
             start_offset: 0,
-            value_length: 5,
             value: vec!['h' as u8, 'E' as u8, 'l' as u8, 'l' as u8, 'O' as u8],
             mask: Some(vec![!0x20; 5]),
             word_size: 1,

--- a/src/magic.rs
+++ b/src/magic.rs
@@ -300,15 +300,11 @@ pub fn lookup_data(entries: &[MagicEntry], data: &[u8]) -> Option<(Mime, u32)> {
 }
 
 pub fn max_extents(entries: &[MagicEntry]) -> usize {
-    let mut res: usize = 0;
-    for entry in entries {
-        let extents = entry.max_extents();
-        if extents > res {
-            res = extents;
-        }
-    }
-
-    res
+    entries
+        .iter()
+        .map(MagicEntry::max_extents)
+        .max()
+        .unwrap_or(0)
 }
 
 pub fn read_magic_from_file<P: AsRef<Path>>(file_name: P) -> Vec<MagicEntry> {

--- a/src/magic.rs
+++ b/src/magic.rs
@@ -449,4 +449,93 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn magic_rule_matches_data() {
+        let rule = MagicRule {
+            indent: 0,
+            start_offset: 0,
+            value_length: 5,
+            value: vec!['h' as u8, 'e' as u8, 'l' as u8, 'l' as u8, 'o' as u8],
+            mask: None,
+            word_size: 1,
+            range_length: 30,
+        };
+
+        assert!(rule.matches_data(b"hello world"));
+        assert!(rule.matches_data(b"world hello"));
+    }
+
+    #[test]
+    fn magic_rule_matches_data_with_start_offset() {
+        let rule = MagicRule {
+            indent: 0,
+            start_offset: 1,
+            value_length: 5,
+            value: vec!['h' as u8, 'e' as u8, 'l' as u8, 'l' as u8, 'o' as u8],
+            mask: None,
+            word_size: 1,
+            range_length: 30,
+        };
+
+        assert!(!rule.matches_data(b"hello world"));
+        assert!(rule.matches_data(b"xhello world"));
+        assert!(rule.matches_data(b"world hello"));
+    }
+
+    #[test]
+    fn magic_rule_matches_data_with_range_length() {
+        let rule = MagicRule {
+            indent: 0,
+            start_offset: 0,
+            value_length: 5,
+            value: vec!['h' as u8, 'e' as u8, 'l' as u8, 'l' as u8, 'o' as u8],
+            mask: None,
+            word_size: 1,
+            range_length: 10,
+        };
+
+        assert!(rule.matches_data(b"hello world"));
+        assert!(rule.matches_data(b"12345hello"));
+        assert!(rule.matches_data(b"123456789hello"));
+        assert!(!rule.matches_data(b"1234567890hello"));
+        assert!(!rule.matches_data(b"too long a prefix for this to match hello"));
+    }
+
+    #[test]
+    fn magic_rule_matches_data_with_start_offset_and_range_length() {
+        let rule = MagicRule {
+            indent: 0,
+            start_offset: 1,
+            value_length: 5,
+            value: vec!['h' as u8, 'e' as u8, 'l' as u8, 'l' as u8, 'o' as u8],
+            mask: None,
+            word_size: 1,
+            range_length: 3,
+        };
+
+        assert!(!rule.matches_data(b"hello world"));
+        assert!(rule.matches_data(b"1hello world"));
+        assert!(rule.matches_data(b"12hello world"));
+        assert!(rule.matches_data(b"123hello world"));
+        assert!(!rule.matches_data(b"1234hello world"));
+    }
+
+    #[test]
+    fn magic_rule_matches_data_with_mask() {
+        let rule = MagicRule {
+            indent: 0,
+            start_offset: 0,
+            value_length: 5,
+            value: vec!['h' as u8, 'E' as u8, 'l' as u8, 'l' as u8, 'O' as u8],
+            mask: Some(vec![!0x20; 5]),
+            word_size: 1,
+            range_length: 30,
+        };
+
+        assert!(rule.matches_data(b"HeLlo world"));
+        assert!(rule.matches_data(b"world HeLlo"));
+        assert!(rule.matches_data(b"12345heLLO"));
+        assert!(!rule.matches_data(b"HuLLO WORLD"));
+    }
 }

--- a/src/magic.rs
+++ b/src/magic.rs
@@ -290,13 +290,10 @@ named!(from_u8_to_entries<Vec<MagicEntry>>,
 );
 
 pub fn lookup_data(entries: &[MagicEntry], data: &[u8]) -> Option<(Mime, u32)> {
-    for entry in entries {
-        if let Some(v) = entry.matches(data) {
-            return Some((v.0.clone(), v.1));
-        }
-    }
-
-    None
+    entries
+        .iter()
+        .find_map(|e| e.matches(data))
+        .map(|v| (v.0.clone(), v.1))
 }
 
 pub fn max_extents(entries: &[MagicEntry]) -> usize {

--- a/src/magic.rs
+++ b/src/magic.rs
@@ -228,15 +228,11 @@ impl MagicEntry {
     }
 
     fn max_extents(&self) -> usize {
-        let mut res: usize = 0;
-        for rule in &self.rules {
-            let rule_extent = rule.extent();
-            if rule_extent > res {
-                res = rule_extent;
-            }
-        }
-
-        res
+        self.rules
+            .iter()
+            .map(MagicRule::extent)
+            .max()
+            .unwrap_or(0)
     }
 }
 

--- a/src/magic.rs
+++ b/src/magic.rs
@@ -57,8 +57,6 @@ fn masked_slices_are_equal(a: &[u8], b: &[u8], mask: &[u8]) -> bool {
 
 impl MagicRule {
     fn matches_data(&self, data: &[u8]) -> bool {
-        // Do we need the value_length at all, if it's implicit in
-        // value.len() and checked by the parsers?
         assert!(self.value_length as usize == self.value.len());
         assert!(self.mask.is_none() || self.mask.as_ref().unwrap().len() == self.value.len());
 


### PR DESCRIPTION
The first ones are straightforward.  The last one is a bit more involved; feel free to ignore it if you think it makes the code harder to read (the tests may still be useful).

I wanted to use `.windows()` on the `data` slice but couldn't find a nice way to limit to the `range_length`.  