### PR TITLE
Use `HashSet` in `GlobMap` to get rid of duplicate entries.

### DIFF
--- a/src/glob.rs
+++ b/src/glob.rs
@@ -4,12 +4,13 @@ use std::io::BufRead;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::collections::HashSet;
 
 use glob::Pattern;
 use mime::Mime;
 use unicase::UniCase;
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum GlobType {
     Literal(String),
     Simple(String),
@@ -44,7 +45,7 @@ fn determine_type(glob: &str) -> GlobType {
     }
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Glob {
     glob: GlobType,
     weight: i32,
@@ -234,20 +235,20 @@ pub fn read_globs_from_dir<P: AsRef<Path>>(dir: P) -> Vec<Glob> {
 }
 
 pub struct GlobMap {
-    globs: Vec<Glob>,
+    globs: HashSet<Glob>,
 }
 
 impl GlobMap {
     pub fn new() -> GlobMap {
-        GlobMap { globs: Vec::new() }
+        GlobMap { globs: HashSet::new() }
     }
 
     pub fn add_glob(&mut self, glob: Glob) {
-        self.globs.push(glob);
+        self.globs.insert(glob);
     }
 
     pub fn add_globs(&mut self, globs: &[Glob]) {
-        self.globs.extend_from_slice(globs);
+        self.globs.extend(globs.iter().map(|glob| glob.clone()));
     }
 
     pub fn lookup_mime_type_for_file_name(&self, file_name: &str) -> Option<Vec<Mime>> {

--- a/src/glob.rs
+++ b/src/glob.rs
@@ -263,18 +263,11 @@ impl GlobMap {
     }
 
     pub fn add_glob(&mut self, glob: Glob) {
-        let weight = glob.weight;
-        if let Some(previous_glob) = self.globs.replace(glob) {
-            if previous_glob.weight > weight {
-                self.globs.insert(previous_glob); // we keep the highest weight.
-            }
-        }
+        self.globs.replace(glob);
     }
 
     pub fn add_globs(&mut self, globs: &[Glob]) {
-        for glob in globs {
-            self.add_glob(glob.clone())
-        }
+        self.globs.extend(globs.iter().map(|glob| glob.clone()));
     }
 
     pub fn lookup_mime_type_for_file_name(&self, file_name: &str) -> Option<Vec<Mime>> {

--- a/src/glob.rs
+++ b/src/glob.rs
@@ -261,7 +261,7 @@ impl GlobMap {
     }
 
     pub fn add_glob(&mut self, glob: Glob) {
-        self.globs.replace(glob);
+        self.globs.insert(glob);
     }
 
     pub fn add_globs(&mut self, globs: &[Glob]) {

--- a/src/glob.rs
+++ b/src/glob.rs
@@ -57,7 +57,6 @@ pub struct Glob {
 impl PartialEq for Glob {
     fn eq(&self, other: &Glob) -> bool {
         self.glob == other.glob &&
-        self.case_sensitive == other.case_sensitive &&
         self.mime_type == other.mime_type
     }
 }
@@ -67,7 +66,6 @@ impl Eq for Glob { }
 impl Hash for Glob {
     fn hash<H: Hasher>(&self, h: &mut H) {
         self.glob.hash(h);
-        self.case_sensitive.hash(h);
         self.mime_type.hash(h)
     }
 }


### PR DESCRIPTION
This fixes #19. It's not the only way if fixing it, and maybe not the best way. In particular, can the problem reappear if two globs are defined for the same mimetype but with different weights?