### PR TITLE
Update to dirs-next as dirs is unmaintained

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ name = "xdg_mime"
 path = "src/lib.rs"
 
 [dependencies]
-dirs = "2.0"
+dirs-next = "2.0"
 glob = "0.3.0"
 mime = "0.3"
 nom = "^5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
-extern crate dirs;
+extern crate dirs_next;
 extern crate nom;
 
 mod alias;
@@ -546,7 +546,7 @@ impl SharedMimeInfo {
     pub fn new() -> SharedMimeInfo {
         let mut db = SharedMimeInfo::create();
 
-        let data_home = dirs::data_dir().expect("Data directory is unset");
+        let data_home = dirs_next::data_dir().expect("Data directory is unset");
         db.load_directory(data_home);
 
         let data_dirs = match env::var_os("XDG_DATA_DIRS") {


### PR DESCRIPTION
According to the rust advisory the dirs dependency is unmaintained and there is a maintained fork [dirs-next](https://crates.io/crates/dirs-next).

https://rustsec.org/advisories/RUSTSEC-2020-0053.html