### PR TITLE
Fix file name mimetype detection to match the spec

### DIFF
--- a/src/glob.rs
+++ b/src/glob.rs
@@ -28,6 +28,16 @@ impl fmt::Debug for GlobType {
     }
 }
 
+impl fmt::Display for GlobType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            GlobType::Literal(str) => write!(f, "{}", str),
+            GlobType::Simple(str) => write!(f, "{}", str),
+            GlobType::Full(pattern) => write!(f, "{}", pattern),
+        }
+    }
+}
+
 fn determine_type(glob: &str) -> GlobType {
     let mut maybe_simple = false;
 
@@ -278,15 +288,29 @@ impl GlobMap {
             }
         }
 
-        if matching_globs.is_empty() {
-            return None;
-        }
-
         // Sort in descending order by weight
         matching_globs.sort_by(|a, b| b.weight.cmp(&a.weight));
 
-        let res = matching_globs
+        let biggest_weight = matching_globs.get(0)?.weight;
+
+        // "Keep only globs with the biggest weight."
+        // -- shared-mime-info, "Recommended checking order"
+        let matching_globs = matching_globs
             .iter()
+            .filter(|glob| glob.weight == biggest_weight);
+
+        // Needs to be after filtering for biggest weight
+        // in case it changes which glob is the longest.
+        let biggest_glob_length = matching_globs
+            .clone()
+            .map(|glob| glob.glob.to_string().len())
+            .max()?;
+
+        // "If the patterns are different, keep only the globs
+        // with the longest pattern, as previously discussed."
+        // -- shared-mime-info, "Recommended checking order"
+        let res = matching_globs
+            .filter(|glob| glob.glob.to_string().len() == biggest_glob_length)
             .map(|glob| glob.mime_type.clone())
             .collect();
 

--- a/src/glob.rs
+++ b/src/glob.rs
@@ -282,7 +282,8 @@ impl GlobMap {
             return None;
         }
 
-        matching_globs.sort_by(|a, b| a.weight.cmp(&b.weight));
+        // Sort in descending order by weight
+        matching_globs.sort_by(|a, b| b.weight.cmp(&a.weight));
 
         let res = matching_globs
             .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -992,6 +992,11 @@ mod tests {
             mime_db.get_mime_types_from_file_name("bar.gif"),
             vec![Mime::from_str("image/gif").unwrap()]
         );
+
+        assert_eq!(
+            mime_db.get_mime_types_from_file_name("baz.mod"),
+            vec![Mime::from_str("audio/x-mod").unwrap()]
+        );
     }
 
     #[test]
@@ -1233,5 +1238,15 @@ mod tests {
             .data(desktop_data)
             .guess();
         assert_eq!(guess.mime_type(), &Mime::from_str("text/plain").unwrap());
+    }
+
+    #[test]
+    fn guess_html_with_no_html_tags() {
+        let mime_db = load_test_data();
+        let mut gb = mime_db.guess_mime_type();
+        let cwd = env::current_dir().unwrap().to_string_lossy().into_owned();
+        let file = PathBuf::from(&format!("{}/test_files/files/no_html_tags.html", cwd));
+        let guess = gb.path(file).guess();
+        assert_eq!(guess.mime_type(), &mime::TEXT_HTML);
     }
 }

--- a/test_files/files/no_html_tags.html
+++ b/test_files/files/no_html_tags.html
@@ -1,0 +1,1 @@
+<p> Hello World! <a href='https://google.com'></a> </p>


### PR DESCRIPTION
According to the "Recommended checking order" section of the [shared-mime-info spec](https://specifications.freedesktop.org/shared-mime-info-spec/shared-mime-info-spec-latest.html#idm46007772955936):

>Keep only globs with the biggest weight. If the patterns are different, keep only globs with the longest pattern, as previously discussed. If after this, there is one or more matching glob, and all the matching globs result in the same mimetype, use that mimetype as the result.

However, currently, all the globs regardless of weight and pattern length are kept from this step. Only the number of mimetypes that match is checked. This can cause some problems, such as html files without `doctype` or `html` tags being detected as plaintext files despite having an `.html` file extension, like in #22.

In addition, this solves #27 because I had to fix the sorting to implement this.