### PR TITLE
Adding in new SharedMimeInfo get_parents_aliased function 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -714,6 +714,31 @@ impl SharedMimeInfo {
         Some(res)
     }
 
+    /// Retrieves all the parent MIME types associated to `mime_type`, without unaliasing.
+    /// You may want to use this to get a list of sub-classes, eg:
+    ///
+    /// ```rust
+    /// use mime::Mime;
+    /// use xdg_mime::SharedMimeInfo;
+    ///
+    /// let parents = (SharedMimeInfo::new()).get_parents_aliased(&Mime::from_str("application/toml")?)?;
+    /// assert!(parents.contains(&mime::TEXT_PLAIN));
+    /// ```
+    pub fn get_parents_aliased(&self, mime_type: &Mime) -> Option<Vec<Mime>> {
+        let mut res = Vec::new();
+
+        if let Some(parents) = self.parents.lookup(&mime_type) {
+            for parent in parents {
+                res.push(parent.clone());
+            }
+        };
+
+        match res.len() {
+            0 => None,
+            _ => Some(res),
+        }
+    }
+
     /// Retrieves the list of matching MIME types for the given file name,
     /// without looking at the data inside the file.
     ///


### PR DESCRIPTION
**changes tl;dr**
- adds in new `get_parents_aliased` function, which functionally is identical to `get_parents` but without unaliasing
- the logic is that i may want to get a list of subclasses (eg: `application/toml` is a sub-class of `text/plain`)

an example of trying to use this would be trying to 'intelligently' open an arbitrary file, where i may want to open a standard text editor (that only registers as a handler for `text/plain`) when i have no specific registered handler for `application/toml` or `application/json` - neither of which would pass the unalias check of `get_parents`