### PR TITLE
perf (glob): use `eq_ignore_ascii_case`

### DIFF
--- a/src/glob.rs
+++ b/src/glob.rs
@@ -165,26 +165,26 @@ impl Glob {
                 let a = UniCase::new(s);
                 let b = UniCase::new(file_name);
 
-                return a == b;
+                a == b
             }
             GlobType::Simple(s) => {
-                if file_name.ends_with(s) {
-                    return true;
+                let file_name_len = file_name.len();
+                let s_len = s.len();
+                if file_name_len < s_len {
+                    return false;
                 }
-
-                if !self.case_sensitive {
-                    let lc_file_name = file_name.to_lowercase();
-                    if lc_file_name.ends_with(s) {
-                        return true;
-                    }
-                }
+                file_name
+                    .get((file_name_len - s_len)..)
+                    .map_or(false, |file_name_end| {
+                        if self.case_sensitive {
+                            file_name_end == *s
+                        } else {
+                            file_name_end.eq_ignore_ascii_case(s)
+                        }
+                    })
             }
-            GlobType::Full(p) => {
-                return p.matches(file_name);
-            }
+            GlobType::Full(p) => p.matches(file_name),
         }
-
-        false
     }
 }
 


### PR DESCRIPTION
See the below profiles for some idea of the performance impact.

Basically, the previous implementation is really inefficient for case-insensitive matches (which are much more common than case-sensitive ones in my testing), since it requires two uses of `ends_with()` and an allocation (because of `to_lowercase()`). Instead, just getting the end of the string and using `eq_ignore_ascii_case()` is significantly faster and avoids any allocations.

This raises the question of non-ascii file extensions, but to my knowledge those don't exist, and even if they did, converting to Unicode lowercase doesn't make sense in this situation I think.

Opening a large folder in `cosmic-files` again:
| #34 (89 ms) | #34 + this PR (42 ms) |
| --- | --- |
| https://share.firefox.dev/4qAVxUV | https://share.firefox.dev/4nVLKGJ |